### PR TITLE
#203: 角丸の操作感を改善・スタイルの調整

### DIFF
--- a/src/components/controls/ColorPicker2.tsx
+++ b/src/components/controls/ColorPicker2.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import { ColorPicker, Typography } from 'antd';
+import React from 'react';
+import { Color } from 'antd/es/color-picker';
+
+const ColorWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+`;
+
+const Description = styled.p`
+  font-size: 0.7rem;
+  text-align: right;
+`;
+
+/**
+ * 全ての値が同じでないことを示す値
+ */
+const NOT_ALL_SAME = '_NOT_ALL_SAME';
+
+/**
+ * カラーピッカーと色の値を表示するコンポーネント
+ */
+export default function ColorPicker2({ onChange, value }: {
+  onChange: (c: string | Color | undefined) => void,
+  value: string | Color | undefined
+}) {
+  const { Text } = Typography;
+
+  return (
+    <ColorWrapper>
+      <ColorPicker
+        size='small'
+        value={value !== NOT_ALL_SAME ? value : undefined}
+        onChangeComplete={(c) => {
+          onChange(c);
+        }}
+      />
+      <Description>
+        {value && value !== NOT_ALL_SAME && <Text type='secondary'>{typeof value === 'object' ? value.toRgbString() : value ?? '#FFFFFF'}</Text>}
+        {value === NOT_ALL_SAME && <Text type='secondary'>決定できません</Text>}
+        {value == undefined && <Text type='secondary'>未選択</Text>}
+      </Description>
+    </ColorWrapper>
+  );
+};

--- a/src/components/tabitems/block/BlockCustomizer.tsx
+++ b/src/components/tabitems/block/BlockCustomizer.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import React, { useContext } from 'react';
 import SubTitle from '../common/SubTitle';
 import Section from '../common/Section';
-import BackgroundColorCustomizer from './BackgroundColorCustomizer';
 import { ElementSelectionContext } from '../../../contexts/ElementSelectionContext';
 import BoxShadowCustomizer from './BoxShadowCustomizer';
 import { PropsContext } from '../../../contexts/PropsContext';
@@ -45,7 +44,7 @@ const BlockCustomizer = () => {
   };
 
   const customizers: { [key: string]: React.JSX.Element } = {
-    背景色: <BackgroundColorCustomizer onChange={onChange} />,
+    // 背景色: <BackgroundColorCustomizer onChange={onChange} />,
     // 幅と高さ: <SizeCustomizer onChange={onChange} />,
     // 余白: <PaddingCustomizer onChange={onChange} />,
     // 角丸: <BorderRadiusCustomizer onChange={onChange} />,

--- a/src/components/tabitems/block/styler/BorderStylerTabContent.tsx
+++ b/src/components/tabitems/block/styler/BorderStylerTabContent.tsx
@@ -255,8 +255,8 @@ export default function BorderStylerTabContent({
    */
   const _additionalContents: Record<string, [React.ReactNode, ((value: any) => void)]> = {
     '色': [<ColorPicker2 value={currentColor} onChange={onChangeColor} />, onChangeColor],
-    'スタイル': [<Select options={borderStyleOptions} defaultValue={undefined} value={borderStyle}
-                     onChange={onChangeStyle} style={{minWidth: '130px'}} />, onChangeStyle],
+    'スタイル': [<Select size={'small'} bordered={false} options={borderStyleOptions} defaultValue={undefined} value={borderStyle}
+                     onChange={onChangeStyle} style={{minWidth: '130px', textAlign: 'right'}} />, onChangeStyle],
     '角丸': [
       <BorderRadius topValue={topValue.radius} rightValue={rightValue.radius} bottomValue={bottomValue.radius}
                     leftValue={leftValue.radius} />, onChangeRadius],

--- a/src/components/tabitems/block/styler/BorderStylerTabContent.tsx
+++ b/src/components/tabitems/block/styler/BorderStylerTabContent.tsx
@@ -2,52 +2,19 @@ import React, { SetStateAction, useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import StylerTabContent from './StylerTabContent';
 import type { Color } from 'antd/es/color-picker';
-import { ColorPicker, Select, Typography } from 'antd';
+import { Select, Typography } from 'antd';
 import useStyleApplier from '../../../../hooks/useStyleApplier';
 import { DefaultOptionType } from 'antd/es/select';
+import ColorPicker2 from '../../../controls/ColorPicker2';
 
 const Wrapper = styled.div`
   width: 100%;
-`;
-
-const ColorWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
 `;
 
 const Description = styled.p`
   font-size: 0.7rem;
   text-align: right;
 `;
-
-/**
- * カラーピッカーと色の値を表示するコンポーネント
- */
-const Color = ({ onChange, value }: {
-  onChange: (c: string | Color | undefined) => void,
-  value: string | undefined
-}) => {
-  const { Text } = Typography;
-
-  return (
-    <ColorWrapper>
-      <ColorPicker
-        size='small'
-        value={value !== NOT_ALL_SAME ? value : undefined}
-        onChangeComplete={(c) => {
-          onChange(c);
-        }}
-      />
-      <Description>
-        {value && value !== NOT_ALL_SAME && <Text type='secondary'>{value}</Text>}
-        {value === NOT_ALL_SAME && <Text type='secondary'>決定できません</Text>}
-        {value == undefined && <Text type='secondary'>未選択</Text>}
-      </Description>
-    </ColorWrapper>
-  );
-};
 
 /**
  * 角丸の値を表示するコンポーネント
@@ -87,6 +54,7 @@ type Props = {
   setRightValue: React.Dispatch<React.SetStateAction<Border>>;
   setBottomValue: React.Dispatch<React.SetStateAction<Border>>;
   setLeftValue: React.Dispatch<React.SetStateAction<Border>>;
+  additionalContents?: Record<string, [React.ReactNode, ((value: any) => void)]>
 }
 
 /**
@@ -100,7 +68,8 @@ export default function BorderStylerTabContent({
                                                  setTopValue,
                                                  setRightValue,
                                                  setBottomValue,
-                                                 setLeftValue
+                                                 setLeftValue,
+                                                 additionalContents = {},
                                                }: Props) {
 
   const styleApplier = useStyleApplier();
@@ -284,13 +253,14 @@ export default function BorderStylerTabContent({
   /**
    * 追加のコンテンツ
    */
-  const additionalContents: Record<string, [React.ReactNode, ((value: any) => void)]> = {
-    '色': [<Color value={currentColor} onChange={onChangeColor} />, onChangeColor],
+  const _additionalContents: Record<string, [React.ReactNode, ((value: any) => void)]> = {
+    '色': [<ColorPicker2 value={currentColor} onChange={onChangeColor} />, onChangeColor],
     'スタイル': [<Select options={borderStyleOptions} defaultValue={undefined} value={borderStyle}
                      onChange={onChangeStyle} style={{minWidth: '130px'}} />, onChangeStyle],
     '角丸': [
       <BorderRadius topValue={topValue.radius} rightValue={rightValue.radius} bottomValue={bottomValue.radius}
-                    leftValue={leftValue.radius} />, onChangeRadius]
+                    leftValue={leftValue.radius} />, onChangeRadius],
+    ...additionalContents
   };
 
   return (
@@ -303,7 +273,7 @@ export default function BorderStylerTabContent({
                         setBottomValue={setBottomWidth} setLeftValue={setLeftWidth}
                         topColor={topValue?.color} rightColor={rightValue?.color}
                         bottomColor={bottomValue?.color} leftColor={leftValue?.color}
-                        additionalContents={additionalContents}
+                        additionalContents={_additionalContents}
                         onDirectionChange={setDirections}
                         onChange={onChangeWidth} />
     </Wrapper>

--- a/src/components/tabitems/block/styler/InteractiveStyler.tsx
+++ b/src/components/tabitems/block/styler/InteractiveStyler.tsx
@@ -132,7 +132,7 @@ export default function InteractiveStyler() {
                             onMouseClick={h.onMouseClickOnMarginStyler} />
         <ResizableComponent baseWidth={ELEMENT_SIZE} baseHeight={ELEMENT_SIZE}
                             offsetX={baseOffsetX - (paddingLeft ?? 0)}
-                            offsetY={baseOffsetY - (paddingTop ?? 0)} isSelected={h.isPaddingSelected}
+                            offsetY={baseOffsetY - (paddingTop ?? 0)} isSelected={h.isPaddingSelected || h.isBorderSelected}
                             top={paddingTop ?? 0} right={paddingRight ?? 0} bottom={paddingBottom ?? 0}
                             left={paddingLeft ?? 0}
                             actualTop={h.paddingTop} actualRight={h.paddingRight} actualBottom={h.paddingBottom}

--- a/src/components/tabitems/block/styler/InteractiveStyler.tsx
+++ b/src/components/tabitems/block/styler/InteractiveStyler.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import ResizableComponent from './ResizableComponent';
-import React, { useContext, useEffect, useMemo } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import BorderRadiusStyler from './BorderRadiusStyler';
 import useInteractiveStylingHelper from '../../../../hooks/useInteractiveStylingHelper';
 import { Tabs, TabsProps } from 'antd';
@@ -8,6 +8,9 @@ import StylerTabContent from './StylerTabContent';
 import BorderStylerTabContent from './BorderStylerTabContent';
 import { ElementSelectionContext } from '../../../../contexts/ElementSelectionContext';
 import { getDecimalFromCSSValue } from '../../../../utils/CSSUtils';
+import ColorPicker2 from '../../../controls/ColorPicker2';
+import { Color } from 'antd/es/color-picker';
+import useStyleApplier from '../../../../hooks/useStyleApplier';
 
 const BASE_SIZE = 200;
 const ELEMENT_SIZE = 50;
@@ -27,6 +30,7 @@ const Wrapper = styled.div`
  */
 export default function InteractiveStyler() {
   const MAX_VALUE = 25;
+  const styleApplier = useStyleApplier();
   const h = useInteractiveStylingHelper();
   const baseOffsetX = useMemo(() => (BASE_SIZE - ELEMENT_SIZE) / 2, []);
   const baseOffsetY = useMemo(() => (BASE_SIZE - ELEMENT_SIZE) / 2, []);
@@ -40,6 +44,21 @@ export default function InteractiveStyler() {
   const marginBottom = useMemo(() => h.marginBottom != undefined ? Math.min(MAX_VALUE, h.marginBottom) : 0, [h.marginBottom]);
   const marginLeft = useMemo(() => h.marginLeft != undefined ? Math.min(MAX_VALUE, h.marginLeft) : undefined, [h.marginLeft]);
 
+  const onChangeColor = useCallback((value: string | Color | undefined) => {
+    h.setBackgroundColor(value);
+    styleApplier.applyStyle('background-color', typeof value === 'object' ? value.toRgbString() : value);
+  }, []);
+
+  /**
+   * 追加のコンテンツ
+   */
+  const additionalContents: Record<string, [React.ReactNode, ((value: any) => void)]> = {
+    '背景色': [<ColorPicker2
+      value={h.backgroundColor}
+      onChange={onChangeColor}
+    />, onChangeColor],
+  };
+
   /**
    * タブの要素
    */
@@ -51,7 +70,8 @@ export default function InteractiveStyler() {
                                   bottomValue={h.paddingBottom}
                                   leftValue={h.paddingLeft}
                                   setTopValue={h.setPaddingTop} setRightValue={h.setPaddingRight}
-                                  setBottomValue={h.setPaddingBottom} setLeftValue={h.setPaddingLeft} />
+                                  setBottomValue={h.setPaddingBottom} setLeftValue={h.setPaddingLeft}
+                                  additionalContents={additionalContents} />
     },
     {
       key: '2',
@@ -60,7 +80,8 @@ export default function InteractiveStyler() {
                                   bottomValue={h.marginBottom}
                                   leftValue={h.marginLeft}
                                   setTopValue={h.setMarginTop} setRightValue={h.setMarginRight}
-                                  setBottomValue={h.setMarginBottom} setLeftValue={h.setMarginLeft} />
+                                  setBottomValue={h.setMarginBottom} setLeftValue={h.setMarginLeft}
+                                  additionalContents={additionalContents} />
     },
     {
       key: '3',
@@ -69,7 +90,8 @@ export default function InteractiveStyler() {
                                         bottomValue={h.borderBottomRight}
                                         leftValue={h.borderBottomLeft}
                                         setTopValue={h.setBorderTopLeft} setRightValue={h.setBorderTopRight}
-                                        setBottomValue={h.setBorderBottomRight} setLeftValue={h.setBorderBottomLeft} />
+                                        setBottomValue={h.setBorderBottomRight} setLeftValue={h.setBorderBottomLeft}
+                                        additionalContents={additionalContents} />
     }
   ];
 
@@ -112,6 +134,7 @@ export default function InteractiveStyler() {
       color: style.borderBottomColor,
       radius: getDecimalFromCSSValue(style.borderBottomLeftRadius)
     });
+    h.setBackgroundColor(style.backgroundColor);
 
   }, [elementSelection.selectedElement]);
 
@@ -139,7 +162,7 @@ export default function InteractiveStyler() {
                             actualLeft={h.paddingLeft}
                             borderTopLeft={h.borderTopLeft} borderTopRight={h.borderTopRight}
                             borderBottomRight={h.borderBottomRight} borderBottomLeft={h.borderBottomLeft}
-                            color={'#ffffff'}
+                            color={typeof h.backgroundColor === 'object' ? h.backgroundColor.toRgbString() : h.backgroundColor ?? '#FFFFFF'}
                             onMouseDown={h.onMouseDownOnPaddingStyler}
                             onMouseClick={h.onMouseClickOnPaddingStyler}>
           {h.isBorderSelected &&

--- a/src/hooks/useInteractiveStylingHelper.ts
+++ b/src/hooks/useInteractiveStylingHelper.ts
@@ -1,5 +1,6 @@
 import React, {useCallback, useRef, useState} from "react";
 import useStyleApplier from './useStyleApplier';
+import { Color } from 'antd/es/color-picker';
 
 type ReturnType = {
   onMouseDownOnMarginStyler: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -18,6 +19,7 @@ type ReturnType = {
   paddingRight: number | undefined;
   paddingBottom: number | undefined;
   paddingLeft: number | undefined;
+  backgroundColor: string | Color | undefined;
   isMarginSelected: boolean;
   isPaddingSelected: boolean;
   isBorderSelected: boolean;
@@ -36,6 +38,7 @@ type ReturnType = {
   setIsMarginSelected: React.Dispatch<React.SetStateAction<boolean>>;
   setIsPaddingSelected: React.Dispatch<React.SetStateAction<boolean>>;
   setIsBorderSelected: React.Dispatch<React.SetStateAction<boolean>>;
+  setBackgroundColor: React.Dispatch<React.SetStateAction<string | Color | undefined>>;
 }
 
 const DIRECTION_RIGHT = 0;
@@ -73,6 +76,7 @@ export default function useInteractiveStylingHelper(): ReturnType {
   const [paddingRight, setPaddingRight] = useState<number | undefined>(undefined);
   const [paddingBottom, setPaddingBottom] = useState<number | undefined>(undefined);
   const [paddingLeft, setPaddingLeft] = useState<number | undefined>(undefined);
+  const [backgroundColor, setBackgroundColor] = useState<string | Color | undefined>(undefined);
 
   const [isMarginSelected, setIsMarginSelected] = useState<boolean>(false);
   const [isPaddingSelected, setIsPaddingSelected] = useState<boolean>(true);
@@ -235,6 +239,7 @@ export default function useInteractiveStylingHelper(): ReturnType {
     paddingRight,
     paddingBottom,
     paddingLeft,
+    backgroundColor,
     isMarginSelected,
     isPaddingSelected,
     isBorderSelected,
@@ -253,5 +258,6 @@ export default function useInteractiveStylingHelper(): ReturnType {
     setIsMarginSelected,
     setIsPaddingSelected,
     setIsBorderSelected,
+    setBackgroundColor,
   }
 }

--- a/src/hooks/useStyleApplier.ts
+++ b/src/hooks/useStyleApplier.ts
@@ -60,7 +60,7 @@ export default function useStyleApplier(): ReturnType {
           cssSelector: getAbsoluteCSSSelector(elementContext.selectedElement),
           values: [{
             key: keyOrArray,
-            value: `${value}`
+            value: value != null ? `${value}` : 'unset',
           }]
         }];
       }


### PR DESCRIPTION
- 角丸の操作感を改善
  - 角丸のインタラクティブな調整UIが不安定だったため、イラレの挙動を完全に模倣するように修正
- No-ContentのUIを改善
<img width="150" alt="image" src="https://github.com/tsukuba-cojt/resta/assets/26784861/7a2ba741-511a-46a9-96df-546ee890e30e">
<img width="150" alt="image" src="https://github.com/tsukuba-cojt/resta/assets/26784861/510d0f8c-03d4-437c-a213-6f59f12d4a3d">
<img width="150" alt="image" src="https://github.com/tsukuba-cojt/resta/assets/26784861/38a5bd51-abe8-4561-8d59-5a97e877f0cd">
