### PR TITLE
テンプレートの作成・編集画面を修正

### DIFF
--- a/src/components/tabitems/template/CreateTemplateByCss.tsx
+++ b/src/components/tabitems/template/CreateTemplateByCss.tsx
@@ -1,12 +1,19 @@
 import styled from 'styled-components';
 import React, { useContext, useEffect, useState } from 'react';
-import { Button, Input, Modal, Select, message } from 'antd';
+import { Button, Input, List, Modal, Select, Typography, message } from 'antd';
+import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
+
 import Section from '../common/Section';
 import SubTitle from '../common/SubTitle';
-import { saveUserTemplates } from '../../../features/userTemplates';
+import {
+  deleteUserTemplates,
+  saveUserTemplates,
+  templateStyleToCssText,
+} from '../../../features/userTemplates';
 import { PropsContext } from '../../../contexts/PropsContext';
 import type { SelectProps } from 'antd';
 import t from '../../../features/translator';
+import { Template } from '../../../types/Template';
 export const CreateTemplateByCss = () => {
   const Description = styled.p`
     font-size: 10pt;
@@ -35,101 +42,189 @@ export const CreateTemplateByCss = () => {
 
   const [messageApi, contextHolder] = message.useMessage();
 
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
+
+  // テンプレートの作成
+  const onCreateOk = async () => {
+    if (css === '') {
+      alert('CSSを入力してください');
+      return;
+    }
+    if (templateName === '') {
+      alert('テンプレート名を入力してください');
+      return;
+    }
+    const templates = prop.userTemplates;
+    if (templates.findIndex((t) => t.name === templateName) > -1) {
+      const ok = confirm(
+        '同じ名前のテンプレートが存在します。上書きしますか？',
+      );
+      if (!ok) {
+        return;
+      }
+    }
+    if (templateName) {
+      try {
+        await saveUserTemplates(css, templateName, tags, prop);
+        setIsCreateModalOpen(false);
+        messageApi.open({
+          type: 'success',
+          content: 'テンプレートを作成しました',
+          duration: 5,
+        });
+      } catch (e) {
+        alert(e);
+      }
+    }
+  };
+
+  // テンプレートの編集
+  const edit = (template: Template) => {
+    setTemplateName(template.name);
+    setTags(template.tags);
+    setCss(templateStyleToCssText(template.styles));
+    setIsEditModalOpen(true);
+  };
+
+  const onEditOk = async () => {
+    try {
+      await saveUserTemplates(css, templateName, tags, prop);
+      setIsEditModalOpen(false);
+      messageApi.open({
+        type: 'success',
+        content: 'テンプレートを作成しました',
+        duration: 5,
+      });
+    } catch (e) {
+      alert(e);
+    }
+  };
+
+  // テンプレートの削除
+  const deleteTemplate = async (template: Template) => {
+    const ok = confirm('テンプレートを削除しますか？');
+    if (ok) {
+      await deleteUserTemplates(template.name, prop);
+    }
+  };
+
+  const onCancel = () => {
+    setTemplateName('');
+    setCss('');
+    setTags([]);
+    setIsCreateModalOpen(false);
+    setIsEditModalOpen(false);
+  };
 
   useEffect(() => {
     setCss('');
     setTemplateName('');
     setTags([]);
-  }, [isModalOpen]);
+  }, [isCreateModalOpen]);
 
   return (
     <>
       {contextHolder}
       <Section>
-        <SubTitle text={'テンプレートの作成'} />
-        <Description>{'CSSを入力してテンプレートを作成します'}</Description>
+        <SubTitle text="テンプレートの作成" />
+        <Description>CSSを入力してテンプレートを作成します</Description>
         <Button
           block
           type="default"
-          onClick={async () => {
-            setIsModalOpen(true);
+          onClick={() => {
+            setIsCreateModalOpen(true);
           }}
         >
           テンプレートを作成
         </Button>
-        <Modal
-          title="テンプレートの作成"
-          open={isModalOpen}
-          onOk={() => {
-            if (css === '') {
-              alert('CSSを入力してください');
-              return;
-            }
-            if (templateName === '') {
-              alert('テンプレート名を入力してください');
-              return;
-            }
-            const templates = prop.userTemplates;
-            if (templates.findIndex((t) => t.name === templateName) > -1) {
-              const ok = confirm(
-                '同じ名前のテンプレートが存在します。上書きしますか？',
-              );
-              if (!ok) {
-                return;
-              }
-            }
-            if (templateName) {
-              saveUserTemplates(css, templateName, tags, prop)
-                .then(() => {
-                  setIsModalOpen(false);
-                  messageApi.open({
-                    type: 'success',
-                    content: 'テンプレートを作成しました',
-                    duration: 5,
-                  });
-                })
-                .catch((e) => {
-                  alert(e);
-                });
-            }
-          }}
-          onCancel={() => setIsModalOpen(false)}
-          zIndex={99999}
-        >
-          <Section>
-            テンプレート名
-            <Input
-              defaultValue={templateName}
-              value={templateName}
-              onChange={(e) => setTemplateName(e.target.value)}
-              contentEditable={true}
-            />
-          </Section>
-          <Section>
-            対象とする要素のタグ名(入力しない場合は全ての要素に適用されます)
-            <Select
-              mode="tags"
-              style={{ width: '100%' }}
-              defaultValue={[]}
-              value={tags?.length === 0 ? [] : tags}
-              tokenSeparators={[',']}
-              onChange={setTags}
-              options={options}
-            />
-          </Section>
-          <Section>
-            CSS
-            <TextArea
-              defaultValue={css}
-              value={css}
-              onChange={(e) => setCss(e.target.value)}
-              contentEditable={true}
-              autoSize={{ minRows: 5, maxRows: 20 }}
-            />
-          </Section>
-        </Modal>
       </Section>
+      <Section>
+        <SubTitle text="作成したテンプレート一覧" />
+        <List
+          dataSource={prop.userTemplates}
+          renderItem={(item) => (
+            <List.Item>
+              <Typography.Text>{item.name}</Typography.Text>
+              <div>
+                <Button
+                  type="ghost"
+                  size="small"
+                  icon={<EditOutlined />}
+                  onClick={() => edit(item)}
+                />
+                <Button
+                  type="ghost"
+                  size="small"
+                  icon={<DeleteOutlined />}
+                  onClick={() => deleteTemplate(item)}
+                />
+              </div>
+            </List.Item>
+          )}
+        />
+      </Section>
+      <Modal
+        title="テンプレートの作成"
+        open={isCreateModalOpen}
+        onOk={onCreateOk}
+        onCancel={onCancel}
+        zIndex={99999}
+      >
+        <Section>
+          テンプレート名
+          <Input
+            defaultValue={templateName}
+            value={templateName}
+            onChange={(e) => setTemplateName(e.target.value)}
+            contentEditable={true}
+          />
+        </Section>
+        <Section>
+          対象とする要素のタグ名（入力しない場合は全ての要素に適用されます）
+          <Select
+            mode="tags"
+            style={{ width: '100%' }}
+            defaultValue={[]}
+            value={tags?.length === 0 ? [] : tags}
+            tokenSeparators={[',']}
+            onChange={setTags}
+            options={options}
+          />
+        </Section>
+        <Section>
+          CSS
+          <TextArea
+            defaultValue={css}
+            value={css}
+            onChange={(e) => setCss(e.target.value)}
+            contentEditable={true}
+            autoSize={{ minRows: 5, maxRows: 20 }}
+          />
+        </Section>
+      </Modal>
+      <Modal
+        title="テンプレートの編集"
+        open={isEditModalOpen}
+        onOk={onEditOk}
+        onCancel={onCancel}
+        zIndex={99999}
+      >
+        <Section>
+          テンプレート名：
+          {templateName}
+        </Section>
+        <Section>
+          CSS
+          <TextArea
+            defaultValue={css}
+            value={css}
+            onChange={(e) => setCss(e.target.value)}
+            contentEditable={true}
+            autoSize={{ minRows: 5, maxRows: 20 }}
+          />
+        </Section>
+      </Modal>
     </>
   );
 };

--- a/src/components/tabitems/template/CreateTemplateByCss.tsx
+++ b/src/components/tabitems/template/CreateTemplateByCss.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import React, { useContext, useEffect, useState } from 'react';
-import { Button, Input, Modal, Select } from 'antd';
+import { Button, Input, Modal, Select, message } from 'antd';
 import Section from '../common/Section';
 import SubTitle from '../common/SubTitle';
 import { saveUserTemplates } from '../../../features/userTemplates';
@@ -33,6 +33,8 @@ export const CreateTemplateByCss = () => {
     { value: 'h3', label: 'h3' },
   ];
 
+  const [messageApi, contextHolder] = message.useMessage();
+
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   useEffect(() => {
@@ -42,73 +44,92 @@ export const CreateTemplateByCss = () => {
   }, [isModalOpen]);
 
   return (
-    <Section>
-      <SubTitle text={'テンプレートの作成'} />
-      <Description>{'CSSを入力してテンプレートを作成します'}</Description>
-      <Button
-        block
-        type="default"
-        onClick={async () => {
-          setIsModalOpen(true);
-        }}
-      >
-        開く
-      </Button>
-      <Modal
-        title="テンプレートの作成"
-        open={isModalOpen}
-        onOk={() => {
-          if (css === '') {
-            alert('CSSを入力してください');
-            return;
-          }
-          if (templateName === '') {
-            alert('テンプレート名を入力してください');
-            return;
-          }
-          saveUserTemplates(css, templateName, tags, prop)
-            .then(() => {
-              setIsModalOpen(false);
-            })
-            .catch((e) => {
-              alert(e);
-            });
-        }}
-        onCancel={() => setIsModalOpen(false)}
-        zIndex={99999}
-      >
-        <Section>
-          テンプレート名
-          <Input
-            defaultValue={templateName}
-            value={templateName}
-            onChange={(e) => setTemplateName(e.target.value)}
-            contentEditable={true}
-          />
-        </Section>
-        <Section>
-          対象とする要素のタグ名(入力しない場合は全ての要素に適用されます)
-          <Select
-            mode="tags"
-            style={{ width: '100%' }}
-            defaultValue={[]}
-            value={tags?.length === 0 ? [] : tags}
-            tokenSeparators={[',']}
-            onChange={setTags}
-            options={options}
-          />
-        </Section>
-        <Section>
-          CSS
-          <TextArea
-            defaultValue={css}
-            value={css}
-            onChange={(e) => setCss(e.target.value)}
-            contentEditable={true}
-            autoSize={{ minRows: 5, maxRows: 20 }}
-          />
-        </Section>
-      </Modal>
-    </Section>
+    <>
+      {contextHolder}
+      <Section>
+        <SubTitle text={'テンプレートの作成'} />
+        <Description>{'CSSを入力してテンプレートを作成します'}</Description>
+        <Button
+          block
+          type="default"
+          onClick={async () => {
+            setIsModalOpen(true);
+          }}
+        >
+          テンプレートを作成
+        </Button>
+        <Modal
+          title="テンプレートの作成"
+          open={isModalOpen}
+          onOk={() => {
+            if (css === '') {
+              alert('CSSを入力してください');
+              return;
+            }
+            if (templateName === '') {
+              alert('テンプレート名を入力してください');
+              return;
+            }
+            const templates = prop.userTemplates;
+            if (templates.findIndex((t) => t.name === templateName) > -1) {
+              const ok = confirm(
+                '同じ名前のテンプレートが存在します。上書きしますか？',
+              );
+              if (!ok) {
+                return;
+              }
+            }
+            if (templateName) {
+              saveUserTemplates(css, templateName, tags, prop)
+                .then(() => {
+                  setIsModalOpen(false);
+                  messageApi.open({
+                    type: 'success',
+                    content: 'テンプレートを作成しました',
+                    duration: 5,
+                  });
+                })
+                .catch((e) => {
+                  alert(e);
+                });
+            }
+          }}
+          onCancel={() => setIsModalOpen(false)}
+          zIndex={99999}
+        >
+          <Section>
+            テンプレート名
+            <Input
+              defaultValue={templateName}
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+              contentEditable={true}
+            />
+          </Section>
+          <Section>
+            対象とする要素のタグ名(入力しない場合は全ての要素に適用されます)
+            <Select
+              mode="tags"
+              style={{ width: '100%' }}
+              defaultValue={[]}
+              value={tags?.length === 0 ? [] : tags}
+              tokenSeparators={[',']}
+              onChange={setTags}
+              options={options}
+            />
+          </Section>
+          <Section>
+            CSS
+            <TextArea
+              defaultValue={css}
+              value={css}
+              onChange={(e) => setCss(e.target.value)}
+              contentEditable={true}
+              autoSize={{ minRows: 5, maxRows: 20 }}
+            />
+          </Section>
+        </Modal>
+      </Section>
+    </>
   );
 };

--- a/src/components/tabitems/template/TemplateList.tsx
+++ b/src/components/tabitems/template/TemplateList.tsx
@@ -28,6 +28,7 @@ const CardsWrapper = styled.div`
   background-color: rgba(255, 255, 255, 0.5);
   border: lightgray solid 1px;
   border-radius: 24px;
+  box-sizing: border-box;
 `;
 
 interface CardsProps {

--- a/src/features/style_sheet.ts
+++ b/src/features/style_sheet.ts
@@ -8,12 +8,12 @@ let styleSheet: CSSStyleSheet | null = null;
  * シングルトンのような構造になっている
  */
 export const getStyleSheet = () => {
-  if (styleSheet == null) {
+  if (styleSheet === null) {
     const styleSheetElement = document.createElement('style');
     document.head.appendChild(styleSheetElement);
-    styleSheet = styleSheetElement.sheet;
+    styleSheet = styleSheetElement.sheet as CSSStyleSheet;
   }
-  return styleSheet as CSSStyleSheet;
+  return styleSheet;
 };
 
 /**


### PR DESCRIPTION
fix: #202 

以下の点を修正しました。
- 同名のテンプレートを作成しようとした際に「同じ名前のテンプレートが存在します。上書きしますか？」を確認ダイアログ表示する
- 「作成したテンプレート一覧」画面を表示する
- テンプレート一覧からは、テンプレートを編集したり、削除したりすることができる
- 編集したテンプレートがリロードするまで適用されないバグを修正
- 作成したボタンが画面幅を超えないようにする